### PR TITLE
feat(calm-widgets): imply context if not specified and fix dot notation bugs

### DIFF
--- a/cli/test_fixtures/template/expected-output/widget-tests/json-viewer-test.md
+++ b/cli/test_fixtures/template/expected-output/widget-tests/json-viewer-test.md
@@ -317,3 +317,25 @@
   }
 ]
 ```
+
+
+
+### Test Partial Document With DotNotation
+
+```json
+[
+  {
+    "unique-id": "load-balancer",
+    "node-type": "network",
+    "name": "Load Balancer",
+    "description": "The attendees service, or a placeholder for another application",
+    "interfaces": [
+      {
+        "unique-id": "load-balancer-host-port",
+        "host": "[[ HOST ]]",
+        "port": -1
+      }
+    ]
+  }
+]
+```

--- a/cli/test_fixtures/template/widget-tests/flow-sequence-test.hbs
+++ b/cli/test_fixtures/template/widget-tests/flow-sequence-test.hbs
@@ -1,1 +1,1 @@
-{{flow-sequence this flow-id="flow-conference-signup"}}
+{{flow-sequence flow-id="flow-conference-signup"}}

--- a/cli/test_fixtures/template/widget-tests/json-viewer-test.hbs
+++ b/cli/test_fixtures/template/widget-tests/json-viewer-test.hbs
@@ -5,3 +5,7 @@
 ### Test Partial Document
 
 {{json-viewer nodes}}
+
+### Test Partial Document With DotNotation
+
+{{json-viewer nodes['load-balancer']}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -38181,6 +38181,7 @@
                 "json-pointer": "^0.6.2",
                 "jsonpath-plus": "^10.3.0",
                 "junit-report-builder": "^5.1.1",
+                "lines-and-columns": "^2.0.4",
                 "lodash": "^4.17.21",
                 "loglevel": "^1.9.2",
                 "mkdirp": "^3.0.1",
@@ -38205,6 +38206,15 @@
                 "memfs": "^4.17.0",
                 "msw": "^2.7.3",
                 "typescript": "^5.8.3"
+            }
+        },
+        "shared/node_modules/lines-and-columns": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.4.tgz",
+            "integrity": "sha512-wM1+Z03eypVAVUCE7QdSqpVIvelbOakn1M0bPDoA4SGWPx3sNDVUiMo3L6To6WWGClB7VyXnhQ4Sn7gxiJbE6A==",
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             }
         }
     }

--- a/shared/package.json
+++ b/shared/package.json
@@ -30,8 +30,8 @@
     "module": "esnext",
     "type": "module",
     "dependencies": {
-        "@finos/calm-models": "file:../calm-models",
         "@apidevtools/json-schema-ref-parser": "^14.0.0",
+        "@finos/calm-models": "file:../calm-models",
         "@stoplight/spectral-cli": "^6.14.3",
         "@stoplight/spectral-core": "^1.19.5",
         "@stoplight/spectral-functions": "^1.9.4",
@@ -43,6 +43,7 @@
         "json-pointer": "^0.6.2",
         "jsonpath-plus": "^10.3.0",
         "junit-report-builder": "^5.1.1",
+        "lines-and-columns": "^2.0.4",
         "lodash": "^4.17.21",
         "loglevel": "^1.9.2",
         "mkdirp": "^3.0.1",

--- a/shared/src/template/template-preprocessor.spec.ts
+++ b/shared/src/template/template-preprocessor.spec.ts
@@ -1,13 +1,305 @@
 import { describe, it, expect } from 'vitest';
 import { TemplatePreprocessor } from './template-preprocessor';
 
-describe('TemplatePreprocessor', () => {
+describe('TemplatePreprocessor.tokenize', () => {
+    it('splits simple body by whitespace', () => {
+        const body = 'list nodes ordered="true"';
+        expect(TemplatePreprocessor.tokenize(body)).toEqual(['list', 'nodes', 'ordered="true"']);
+    });
+
+    it('trims leading/trailing whitespace', () => {
+        const body = '   list   nodes   ';
+        expect(TemplatePreprocessor.tokenize(body)).toEqual(['list', 'nodes']);
+    });
+
+    it('collapses multiple spaces', () => {
+        const body = 'list    nodes    extra=1';
+        expect(TemplatePreprocessor.tokenize(body)).toEqual(['list', 'nodes', 'extra=1']);
+    });
+
+    it('handles quoted extras as single tokens (basic)', () => {
+        const body = 'list nodes ordered="true" property="name"';
+        expect(TemplatePreprocessor.tokenize(body)).toEqual(['list', 'nodes', 'ordered="true"', 'property="name"']);
+    });
+
+    it('handles brackets etc', () => {
+        const body = 'list nodes["unique-id"].details ordered="true" property="name"';
+        expect(TemplatePreprocessor.tokenize(body)).toEqual(['list', 'nodes["unique-id"].details', 'ordered="true"', 'property="name"']);
+    });
+
+    it('handles brackets with spaces inside', () => {
+        const body = 'list nodes["unique id"].details ordered="true" property="name"';
+        expect(TemplatePreprocessor.tokenize(body)).toEqual(['list', 'nodes["unique id"].details', 'ordered="true"', 'property="name"']);
+    });
+
+    it('handles single-quoted KV', () => {
+        const body = 'list nodes ordered=\'true\' property=\'display name\'';
+        expect(TemplatePreprocessor.tokenize(body)).toEqual(['list', 'nodes', 'ordered=\'true\'', 'property=\'display name\'']);
+    });
+
+    it('keeps URL-ish unquoted values together', () => {
+        const body = 'list nodes url=https://example.com/path?x=1&y=2';
+        expect(TemplatePreprocessor.tokenize(body)).toEqual(['list', 'nodes', 'url=https://example.com/path?x=1&y=2']);
+    });
+
+    it('supports numeric bracket indices and chained brackets', () => {
+        const body = 'list nodes[0][1].details depth=2';
+        expect(TemplatePreprocessor.tokenize(body)).toEqual(['list', 'nodes[0][1].details', 'depth=2']);
+    });
+
+    it('supports consecutive bracketed string keys', () => {
+        const body = 'list nodes[\'foo\'][\'bar baz\'][0]';
+        expect(TemplatePreprocessor.tokenize(body)).toEqual(['list', 'nodes[\'foo\'][\'bar baz\'][0]']);
+    });
+
+    it('handles chain starting with bracket', () => {
+        const body = 'list ["root key"].child other=1';
+        expect(TemplatePreprocessor.tokenize(body)).toEqual(['list', '["root key"].child', 'other=1']);
+    });
+
+    it('handles escaped quotes inside double-quoted KV', () => {
+        const body = 'title="He said \\"hi\\"" kind=item';
+        expect(TemplatePreprocessor.tokenize(body)).toEqual(['title="He said \\"hi\\""', 'kind=item']);
+    });
+
+    it('handles escaped quotes inside single-quoted KV', () => {
+        const body = 'title=\'He said \\\'hi\\\'\' kind=item';
+        expect(TemplatePreprocessor.tokenize(body)).toEqual(['title=\'He said \\\'hi\\\'\'', 'kind=item']);
+    });
+
+    it('keeps @root tokens together', () => {
+        const body = '@root.nodes["id with space"]';
+        expect(TemplatePreprocessor.tokenize(body)).toEqual(['@root.nodes["id with space"]']);
+    });
+
+    it('keeps dot-chains without brackets together', () => {
+        const body = 'architecture.nodes.details';
+        expect(TemplatePreprocessor.tokenize(body)).toEqual(['architecture.nodes.details']);
+    });
+
+    it('handles tabs and newlines as whitespace', () => {
+        const body = 'list\tnodes\nordered="true"\tproperty="name"';
+        expect(TemplatePreprocessor.tokenize(body)).toEqual(['list', 'nodes', 'ordered="true"', 'property="name"']);
+    });
+
+    it('single KV only', () => {
+        const body = 'ordered="true"';
+        expect(TemplatePreprocessor.tokenize(body)).toEqual(['ordered="true"']);
+    });
+
+    it('multiple KVs with mixed quoting', () => {
+        const body = 'a=1 b="two words" c=\'three words\' d=four';
+        expect(TemplatePreprocessor.tokenize(body)).toEqual(['a=1', 'b="two words"', 'c=\'three words\'', 'd=four']);
+    });
+
+    it('handles parentheses as single token (no nesting)', () => {
+        const body = '(alpha beta) gamma';
+        expect(TemplatePreprocessor.tokenize(body)).toEqual(['(alpha beta)', 'gamma']);
+    });
+
+    it('KV with parens value without spaces is one token', () => {
+        const body = 'expr=(a+b*c) next=1';
+        expect(TemplatePreprocessor.tokenize(body)).toEqual(['expr=(a+b*c)', 'next=1']);
+    });
+
+    it('does not split on hyphens in identifiers', () => {
+        const body = 'flow-sequence nodes[0].details flow-id="x"';
+        expect(TemplatePreprocessor.tokenize(body)).toEqual(['flow-sequence', 'nodes[0].details', 'flow-id="x"']);
+    });
+
+    it('handles mixed bracket string and numeric index then dot', () => {
+        const body = 'nodes[\'k v\'][2].child other="z"';
+        expect(TemplatePreprocessor.tokenize(body)).toEqual(['nodes[\'k v\'][2].child', 'other="z"']);
+    });
+
+    it('handles trailing/leading heavy whitespace', () => {
+        const body = '   list   nodes[0]   prop="x"   ';
+        expect(TemplatePreprocessor.tokenize(body)).toEqual(['list', 'nodes[0]', 'prop="x"']);
+    });
+
+    it('keeps unknown symbols as part of tokens via fallback', () => {
+        const body = '#weird token';
+        expect(TemplatePreprocessor.tokenize(body)).toEqual(['#weird', 'token']);
+    });
+
+    it('KV with equals signs inside quoted value', () => {
+        const body = 'filter="a==b && c!=d"';
+        expect(TemplatePreprocessor.tokenize(body)).toEqual(['filter="a==b && c!=d"']);
+    });
+
+    it('handles bracket content with equals and quotes', () => {
+        const body = 'nodes[\'id=="Upload Service"\' ].details';
+        expect(TemplatePreprocessor.tokenize(body)).toEqual(['nodes[\'id=="Upload Service"\' ].details']);
+    });
+
+    it('chain with alternating bracket and dot segments', () => {
+        const body = 'a[\'x y\'].b["c d"][0].e';
+        expect(TemplatePreprocessor.tokenize(body)).toEqual(['a[\'x y\'].b["c d"][0].e']);
+    });
+
+    it('unquoted KV with punctuation in value stays single token', () => {
+        const body = 'pattern=a*b+c?d';
+        expect(TemplatePreprocessor.tokenize(body)).toEqual(['pattern=a*b+c?d']);
+    });
+
+    it('multiple chains and KVs together', () => {
+        const body = 'list a.b["c d"][0] x.y z[1][\'q w\'] key="val 1" k2=\'v 2\' k3=v3';
+        expect(TemplatePreprocessor.tokenize(body)).toEqual([
+            'list',
+            'a.b["c d"][0]',
+            'x.y',
+            'z[1][\'q w\']',
+            'key="val 1"',
+            'k2=\'v 2\'',
+            'k3=v3',
+        ]);
+    });
+
+    it('subexpression is a single token', () => {
+        const body = '(eq elementType "Person")';
+        expect(TemplatePreprocessor.tokenize(body)).toEqual(['(eq elementType "Person")']);
+    });
+});
+
+describe('TemplatePreprocessor.interpretTokens', () => {
+    it('1 token → standalone context path', () => {
+        const t = TemplatePreprocessor.interpretTokens(['nodes']);
+        expect(t).toEqual({ contextPath: 'nodes', impliedThis: false, isStandalonePath: true });
+    });
+
+    it('2 tokens → helper + context path', () => {
+        const t = TemplatePreprocessor.interpretTokens(['list', 'nodes']);
+        expect(t).toEqual({ helper: 'list', contextPath: 'nodes', impliedThis: false, isStandalonePath: false });
+    });
+
+    it('2 tokens with KV → helper + implied this + extras', () => {
+        const t = TemplatePreprocessor.interpretTokens(['list', 'ordered="true"']);
+        expect(t).toEqual({ helper: 'list', contextPath: 'this', extras: 'ordered="true"', impliedThis: true, isStandalonePath: false });
+    });
+
+    it('>2 tokens → helper + context path + extras', () => {
+        const t = TemplatePreprocessor.interpretTokens(['list', 'nodes', 'ordered="true"', 'property="name"']);
+        expect(t).toEqual({ helper: 'list', contextPath: 'nodes', extras: 'ordered="true" property="name"', impliedThis: false, isStandalonePath: false });
+    });
+
+    it('second token KV with more extras', () => {
+        const t = TemplatePreprocessor.interpretTokens(['flow-sequence', 'flow-id="x"', 'property="y"']);
+        expect(t).toEqual({ helper: 'flow-sequence', contextPath: 'this', extras: 'flow-id="x" property="y"', impliedThis: true, isStandalonePath: false });
+    });
+
+    it('does not mistake equals inside bracket path as KV', () => {
+        const t = TemplatePreprocessor.interpretTokens(['list', 'nodes[\'id=="A"\']', 'ordered="true"']);
+        expect(t).toEqual({ helper: 'list', contextPath: 'nodes[\'id=="A"\']', extras: 'ordered="true"', impliedThis: false, isStandalonePath: false });
+    });
+
+    it('explicit this as context still treated as context path', () => {
+        const t = TemplatePreprocessor.interpretTokens(['flow-sequence', 'this', 'flow-id="x"']);
+        expect(t).toEqual({ helper: 'flow-sequence', contextPath: 'this', extras: 'flow-id="x"', impliedThis: false, isStandalonePath: false });
+    });
+
+    it('helper + path + mixed extras', () => {
+        const t = TemplatePreprocessor.interpretTokens(['join', 'a.b', '", "', 'limit=5']);
+        expect(t).toEqual({
+            helper: 'join',
+            contextPath: 'a.b',
+            extras: '", " limit=5',
+            impliedThis: false,
+            isStandalonePath: false
+        });
+    });
+});
+
+describe('TemplatePreprocessor.findMustacheSegments', () => {
+    it('finds single simple segment', () => {
+        const input = 'Hello {{user.name}}!';
+        const segs = TemplatePreprocessor.findMustacheSegments(input);
+        expect(segs.length).toBe(1);
+        expect(segs[0].full).toBe('{{user.name}}');
+        expect(segs[0].body).toBe('user.name');
+        expect(segs[0].line).toBe(1);
+        expect(segs[0].column).toBe(7);
+        expect(input.slice(segs[0].start, segs[0].end)).toBe(segs[0].full);
+    });
+
+    it('finds multiple segments across lines', () => {
+        const input = `
+      {{list nodes['unique-id=="A"'] ordered="true"}}
+      {{summary nodes["unique-id==\\"B\\""]}}
+    `;
+        const segs = TemplatePreprocessor.findMustacheSegments(input);
+        expect(segs.length).toBe(2);
+        expect(segs[0].body).toBe('list nodes[\'unique-id=="A"\'] ordered="true"');
+        expect(segs[0].line).toBe(2);
+        expect(segs[0].column).toBe(7);
+        expect(segs[1].body).toBe('summary nodes["unique-id==\\"B\\""]');
+        expect(segs[1].line).toBe(3);
+        expect(segs[1].column).toBe(7);
+    });
+
+    it('includes control tags for now', () => {
+        const input = `
+      {{#each items}}
+        {{this}}
+      {{/each}}
+    `;
+        const segs = TemplatePreprocessor.findMustacheSegments(input);
+        expect(segs.length).toBe(3);
+        expect(segs.map(s => s.body.trim())).toEqual([
+            '#each items',
+            'this',
+            '/each',
+        ]);
+        expect(segs[0].line).toBe(2);
+        expect(segs[0].column).toBe(7);
+        expect(segs[1].line).toBe(3);
+        expect(segs[1].column).toBe(9);
+        expect(segs[2].line).toBe(4);
+        expect(segs[2].column).toBe(7);
+    });
+
+    it('captures indices correctly for slicing', () => {
+        const input = 'a{{x}}b{{y.z}}c';
+        const segs = TemplatePreprocessor.findMustacheSegments(input);
+        expect(segs.length).toBe(2);
+        const s0 = input.slice(segs[0].start, segs[0].end);
+        const s1 = input.slice(segs[1].start, segs[1].end);
+        expect(s0).toBe('{{x}}');
+        expect(s1).toBe('{{y.z}}');
+        expect(segs[0].line).toBe(1);
+        expect(segs[0].column).toBe(2);
+        expect(segs[1].line).toBe(1);
+        expect(segs[1].column).toBe(8);
+    });
+
+    it('handles bracket filters and quotes', () => {
+        const input = '{{nodes[\'id=="Upload Service"\'][0].details}}';
+        const segs = TemplatePreprocessor.findMustacheSegments(input);
+        expect(segs.length).toBe(1);
+        expect(segs[0].body).toBe('nodes[\'id=="Upload Service"\'][0].details');
+        expect(segs[0].line).toBe(1);
+        expect(segs[0].column).toBe(1);
+    });
+
+    it('ignores braces outside mustache', () => {
+        const input = '{{a}} { not } {{b.c}}';
+        const segs = TemplatePreprocessor.findMustacheSegments(input);
+        expect(segs.length).toBe(2);
+        expect(segs[0].body).toBe('a');
+        expect(segs[1].body).toBe('b.c');
+        expect(segs[0].line).toBe(1);
+        expect(segs[0].column).toBe(1);
+        expect(segs[1].line).toBe(1);
+        expect(segs[1].column).toBe(15);
+    });
+});
+
+describe('TemplatePreprocessor.preprocessTemplate', () => {
     it('rewrites path with single quotes and extras', () => {
         const input = '{{list nodes[\'unique-id=="Upload Service"\'] ordered="true" property="name"}}';
         const output = TemplatePreprocessor.preprocessTemplate(input);
 
         expect(output).toBe(
-            '{{list (convertFromDotNotation this "nodes[\'unique-id==\\"Upload Service\\"\']"  ordered="true" property="name") ordered="true" property="name"}}'
+            '{{list (convertFromDotNotation this "nodes[\'unique-id==\\"Upload Service\\"\']" ordered="true" property="name") ordered="true" property="name"}}'
         );
     });
 
@@ -15,21 +307,21 @@ describe('TemplatePreprocessor', () => {
         const input = '{{list nodes[\'unique-id=="Upload Service"\']}}';
         const output = TemplatePreprocessor.preprocessTemplate(input);
 
-        expect(output).toBe('{{list (convertFromDotNotation this "nodes[\'unique-id==\\"Upload Service\\"\']" )}}');
+        expect(output).toBe('{{list (convertFromDotNotation this "nodes[\'unique-id==\\"Upload Service\\"\']")}}');
     });
 
     it('rewrites path with double quotes already present', () => {
         const input = '{{list nodes[unique-id=="Upload Service"]}}';
         const output = TemplatePreprocessor.preprocessTemplate(input);
 
-        expect(output).toBe('{{list (convertFromDotNotation this "nodes[unique-id==\\"Upload Service\\"]" )}}');
+        expect(output).toBe('{{list (convertFromDotNotation this "nodes[unique-id==\\"Upload Service\\"]")}}');
     });
 
     it('leaves non-convertFromDotNotation able paths unchanged', () => {
         const input = '{{list nodes ordered="true"}}';
         const output = TemplatePreprocessor.preprocessTemplate(input);
 
-        expect(output).toBe('{{list (convertFromDotNotation this "nodes"  ordered="true") ordered="true"}}');
+        expect(output).toBe('{{list nodes ordered="true"}}');
     });
 
     it('handles multiple occurrences in the same template', () => {
@@ -39,8 +331,8 @@ describe('TemplatePreprocessor', () => {
         `;
         const output = TemplatePreprocessor.preprocessTemplate(input);
 
-        expect(output).toContain('{{list (convertFromDotNotation this "nodes[\'unique-id==\\"A\\"\']"  ordered="true") ordered="true"}}');
-        expect(output).toContain('{{summary (convertFromDotNotation this "nodes[\'unique-id==\\"B\\"\']" )}}');
+        expect(output).toContain('{{list (convertFromDotNotation this "nodes[\'unique-id==\\"A\\"\']" ordered="true") ordered="true"}}');
+        expect(output).toContain('{{summary (convertFromDotNotation this "nodes[\'unique-id==\\"B\\"\']")}}');
     });
 
     it('wraps nodes[...] without helper as convertFromDotNotation', () => {
@@ -65,7 +357,166 @@ describe('TemplatePreprocessor', () => {
         const input = '{{list relationships[\'deployed-in-k8s-cluster\'][\'relationship-type\'][\'deployed-in\'].nodes ordered="true"}}';
         const output = TemplatePreprocessor.preprocessTemplate(input);
 
-        expect(output).toBe('{{list (convertFromDotNotation this "relationships[\'deployed-in-k8s-cluster\'][\'relationship-type\'][\'deployed-in\'].nodes"  ordered="true") ordered="true"}}');
+        expect(output).toBe('{{list (convertFromDotNotation this "relationships[\'deployed-in-k8s-cluster\'][\'relationship-type\'][\'deployed-in\'].nodes" ordered="true") ordered="true"}}');
     });
+
+    it('rewrites standalone dotted path', () => {
+        const input = '{{a.b.c}}';
+        const output = TemplatePreprocessor.preprocessTemplate(input);
+        expect(output).toBe('{{a.b.c}}');
+    });
+
+    it('helper with explicit path gets wrapped, extras preserved', () => {
+        const input = '{{join relationship-type.interacts.nodes ", "}}';
+        const output = TemplatePreprocessor.preprocessTemplate(input);
+        expect(output).toBe('{{join relationship-type.interacts.nodes ", "}}');
+    });
+
+    it('helper with implied this (second token is KV) adds explicit this', () => {
+        const input = '{{flow-sequence flow-id="x" type="short"}}';
+        const output = TemplatePreprocessor.preprocessTemplate(input);
+        expect(output).toBe('{{flow-sequence this flow-id="x" type="short"}}');
+    });
+
+    it('leaves reserved standalone paths', () => {
+        expect(TemplatePreprocessor.preprocessTemplate('{{this}}')).toBe('{{this}}');
+        expect(TemplatePreprocessor.preprocessTemplate('{{.}}')).toBe('{{.}}');
+        expect(TemplatePreprocessor.preprocessTemplate('{{true}}')).toBe('{{true}}');
+        expect(TemplatePreprocessor.preprocessTemplate('{{false}}')).toBe('{{false}}');
+        expect(TemplatePreprocessor.preprocessTemplate('{{null}}')).toBe('{{null}}');
+        expect(TemplatePreprocessor.preprocessTemplate('{{undefined}}')).toBe('{{undefined}}');
+        expect(TemplatePreprocessor.preprocessTemplate('{{lookup}}')).toBe('{{lookup}}');
+    });
+
+    it('leaves relative paths unchanged', () => {
+        expect(TemplatePreprocessor.preprocessTemplate('{{../unique-id}}')).toBe('{{../unique-id}}');
+        expect(TemplatePreprocessor.preprocessTemplate('{{./name}}')).toBe('{{./name}}');
+    });
+
+    it('rewrites #each opener context path and preserves block params', () => {
+        const input = '{{#each items as |i|}}';
+        const output = TemplatePreprocessor.preprocessTemplate(input);
+        expect(output).toBe('{{#each items as |i|}}');
+    });
+
+    it('block opener with dotted path gets wrapped and params kept', () => {
+        const input = '{{#with a.b.c as |ctx|}}';
+        const output = TemplatePreprocessor.preprocessTemplate(input);
+        expect(output).toBe('{{#with a.b.c as |ctx|}}');
+    });
+
+    it('leaves #if with subexpression unchanged', () => {
+        const input = '{{#if (eq elementType "Person")}}';
+        const output = TemplatePreprocessor.preprocessTemplate(input);
+        expect(output).toBe('{{#if (eq elementType "Person")}}');
+    });
+
+    it('control tags are untouched', () => {
+        const src = [
+            '{{/each}}',
+            '{{! comment}}',
+            '{{> partial}}',
+            '{{^cond}}',
+            '{{else}}'
+        ].join('\n');
+        const out = TemplatePreprocessor.preprocessTemplate(src);
+        expect(out).toBe(src);
+    });
+
+    it('emits correct kinds across a small mixed template', () => {
+        const src = `
+{{#each nodes as |n|}}
+- {{n.name}}
+{{/each}}
+{{lookup}}
+{{flow-sequence flow-id="x"}}
+{{a.b}}
+`.trim();
+
+        const decisions = TemplatePreprocessor.analyzeTemplate(src);
+        // Expect 6 segments in order:
+        // 0: #each nodes as |n|    -> leave
+        // 1: n.name                -> leave
+        // 2: /each                 -> control
+        // 3: lookup                -> leave
+        // 4: flow-sequence flow-id -> rewrite (implied this)
+        // 5: a.b                   -> leave
+        expect(decisions.length).toBe(6);
+
+        expect(decisions[0].kind).toBe('leave');
+        expect(decisions[1].kind).toBe('leave');
+        expect(decisions[2].kind).toBe('control');
+        expect(decisions[3].kind).toBe('leave');
+        expect(decisions[4].kind).toBe('rewrite');
+        expect(decisions[5].kind).toBe('leave');
+    });
+
+    it('subexpression standalone is left', () => {
+        const src = '{{(eq a b)}}';
+        const [d] = TemplatePreprocessor.analyzeTemplate(src);
+        expect(d.kind).toBe('leave');
+    });
+
+    it('relative path standalone is left', () => {
+        const src = '{{../x}}';
+        const [d] = TemplatePreprocessor.analyzeTemplate(src);
+        expect(d.kind).toBe('leave');
+    });
+
+    it('reserved context (not "this" or ".") inside helper is left', () => {
+        const src = '{{list @index}}';
+        const [d] = TemplatePreprocessor.analyzeTemplate(src);
+        expect(d.kind).toBe('leave');
+    });
+
+    it('rewrites from right to left without corrupting indices', () => {
+        const input = 'X {{a.b}} Y {{c.d.e}} Z {{list nodes ", "}}';
+        const out = TemplatePreprocessor.preprocessTemplate(input);
+        expect(out).toBe(
+            'X {{a.b}} Y {{c.d.e}} Z {{list nodes ", "}}'
+        );
+    });
+
+    it('leaves native Handlebars literal-segment paths unchanged in block helpers', () => {
+        const input = `
+      {{#with nodes.[0]}}
+        {{unique-id}}
+      {{/with}}
+    `;
+        const out = TemplatePreprocessor.preprocessTemplate(input);
+        expect(out).toBe(
+            `
+      {{#with nodes.[0]}}
+        {{unique-id}}
+      {{/with}}
+    `
+        );
+    });
+
+
+
+    it('leaves helper with native path and no dot-notation hashes unchanged', () => {
+        const input = '{{table nodes key="unique-id" columns="node-type, description"}}';
+        const out = TemplatePreprocessor.preprocessTemplate(input);
+        expect(out).toBe('{{table nodes key="unique-id" columns="node-type, description"}}');
+    });
+
+    it('rewrites helper when filter hash is present', () => {
+        const input = '{{table nodes key="unique-id" columns="node-type, description" filter="node-type==\'database\'"}}';
+        const out = TemplatePreprocessor.preprocessTemplate(input);
+        expect(out).toBe(
+            '{{table (convertFromDotNotation this "nodes" key="unique-id" columns="node-type, description" filter="node-type==\'database\'") key="unique-id" columns="node-type, description" filter="node-type==\'database\'"}}'
+        );
+    });
+
+    it('rewrites helper when sort or limit hashes are present', () => {
+        const input = '{{table nodes sort="name:asc" limit=10}}';
+        const out = TemplatePreprocessor.preprocessTemplate(input);
+        expect(out).toBe(
+            '{{table (convertFromDotNotation this "nodes" sort="name:asc" limit=10) sort="name:asc" limit=10}}'
+        );
+    });
+
+
 
 });

--- a/shared/src/template/template-preprocessor.ts
+++ b/shared/src/template/template-preprocessor.ts
@@ -1,39 +1,457 @@
+import { LinesAndColumns } from 'lines-and-columns';
+
+export type Seg = {
+    full: string;
+    body: string;
+    start: number;
+    end: number;
+    line: number;
+    column: number;
+};
+
+type SegmentDecision =
+    | { kind: 'control'; seg: Seg }
+    | { kind: 'leave'; seg: Seg; reason?: string }
+    | { kind: 'rewrite'; seg: Seg; newText: string }
+    | { kind: 'invalid'; seg: Seg; reason: string };
+
+
+/**
+ * # TemplatePreprocessor
+ * ## Background & Design Decision
+ *
+ * This preprocessor exists because we want non-technical users to write intuitive template syntax
+ * like `{{json-viewer nodes['load-balancer']}}` or `{{nodes['unique-id=="auth-service"'].name}}`,
+ * even though Handlebars doesn't natively support bracket filtering or complex predicates in paths.
+ *
+ * See https://github.com/finos/architecture-as-code/issues/1556#issuecomment-3243213264
+ *
+ * ## High-level Approach
+ * 1. **Segment discovery** – Regex scan for `{{ … }}`; each match is a `Seg`.
+ * 2. **Tokenization** – Breaks `body` into identifiers, brackets, quoted strings, KVs,
+ *    subexpressions, etc.
+ * 3. **Interpretation** – Decide if it's a standalone path, helper call, block opener,
+ *    control tag, reserved path, or subexpression.
+ * 4. **Rewrite** – Only context paths get wrapped:
+ *    - `{{foo.bar}}` → `{{convertFromDotNotation this "foo.bar"}}`
+ *    - `{{#each items as |i|}}` → `{{#each (convertFromDotNotation this "items") as |i|}}`
+ *    - `{{helper kv=1}}` → `{{helper this kv=1}}`
+ *    - reserved, relative (`../`), subexpressions `(eq x y)` → left unchanged
+ * 5. **Replacements** – Apply back into the template string from end → start.
+ *
+ * ## Why blocks vs non-blocks?
+ * Handlebars blocks (`{{#each …}}…{{/each}}`) alter scope, may include block params (`as |…|`),
+ * and have open/close/else sections. Only the *opener's* context path should be rewritten.
+ * Non-blocks are simple value lookups or helper calls.
+ *
+ * ## Reserved / Special Cases
+ * - Reserved: `this`, `.`, `true`, `false`, `null`, `undefined`, `lookup`, `@index`, `@root`, etc.
+ * - Subexpressions: `(eq kind "Person")` are not rewritten.
+ * - Relative paths: `../x`, `./y` are not rewritten.
+ * - Control: `/each`, `! comment`, `> partial`, `else` are not rewritten.
+ *
+ * ## Error Handling
+ * - Returns a `SegmentDecision` union for each segment:
+ *   - `rewrite` → replaced with `newText`
+ *   - `leave` → left unchanged, with a reason
+ *   - `control` → block/control marker
+ *   - `invalid` → malformed helper/path
+ * - In the future a user would be able to build template and see live warnings/errors.
+ *
+ */
 export class TemplatePreprocessor {
+    private static readonly CONVERT_FN = 'convertFromDotNotation';
+
+    /**
+     * Scans template string for mustache segments `{{ ... }}` and extracts their positions.
+     * Returns array of segments with body content, start/end indices, and line/column positions.
+     */
+    static findMustacheSegments(template: string): Seg[] {
+        const out: Seg[] = [];
+        const re = /{{\s*([^{}]+?)\s*}}/g;
+        const lac = new LinesAndColumns(template);
+
+        let m: RegExpExecArray | null;
+        while ((m = re.exec(template)) !== null) {
+            const start = m.index;
+            const end = m.index + m[0].length;
+
+            const loc = lac.locationForIndex(start) ?? { line: 0, column: 0 };
+
+            out.push({
+                full: m[0],
+                body: m[1],
+                start,
+                end,
+                line: loc.line + 1,     // 1-based if you prefer
+                column: loc.column + 1,
+            } as Seg & { line: number; column: number });
+        }
+        return out;
+    }
+
+    /**
+     * Breaks mustache body text into semantic tokens like identifiers, paths, key-value pairs, and subexpressions.
+     * Handles complex cases like bracket notation, quoted strings, and chained property access.
+     */
+    static tokenize(body: string): string[] {
+        const s = body.trim();
+        if (!s) return [];
+        const IDENTIFIER = String.raw`@?[A-Za-z0-9_$-]+`;
+        const DOUBLE_QUOTED = String.raw`"(?:[^"\\]|\\.)*"`;
+        const SINGLE_QUOTED = String.raw`'(?:[^'\\]|\\.)*'`;
+        const BRACKET_EXPR = String.raw`\[[^\]]*\]`;
+        const PAREN_EXPR = String.raw`\([^)]*\)`;
+        const PATH_SEGMENT = String.raw`(?:${IDENTIFIER}|${BRACKET_EXPR})`;
+        const PATH_CHAIN = String.raw`${PATH_SEGMENT}(?:(?:\.${IDENTIFIER})|(?:\.${BRACKET_EXPR})|${BRACKET_EXPR})*`;
+        const KEY_VALUE_PAIR = String.raw`${IDENTIFIER}\s*=\s*(?:${DOUBLE_QUOTED}|${SINGLE_QUOTED}|[^\s]+)`;
+
+        const TOKEN_REGEX = new RegExp(
+            `${KEY_VALUE_PAIR}|${PATH_CHAIN}|${PAREN_EXPR}|${DOUBLE_QUOTED}|${SINGLE_QUOTED}|\\S+`,
+            'g'
+        );
+
+        const KV_NORMALIZE = new RegExp(
+            `^(${IDENTIFIER})\\s*=\\s*(${DOUBLE_QUOTED}|${SINGLE_QUOTED}|[^\\s]+)$`
+        );
+
+        const tokens: string[] = [];
+        for (const m of s.matchAll(TOKEN_REGEX)) {
+            const raw = m[0];
+            const kv = raw.match(KV_NORMALIZE);
+            tokens.push(kv ? `${kv[1]}=${kv[2]}` : raw);
+        }
+        return tokens;
+    }
+
+    /**
+     * Analyzes tokenized mustache content to determine if it's a standalone path, helper call, or has implied context.
+     * Returns structured information about helper name, context path, extras, and path type classification.
+     */
+    static interpretTokens(tokens: string[]): {
+        helper?: string;
+        contextPath?: string;
+        extras?: string;
+        impliedThis: boolean;
+        isStandalonePath: boolean;
+    } {
+        const isKV = (t: string) => /^@?[A-Za-z0-9_$-]+=/.test(t);
+        if (tokens.length === 0) return { impliedThis: false, isStandalonePath: false };
+        if (tokens.length === 1) {
+            return { contextPath: tokens[0], impliedThis: false, isStandalonePath: true };
+        }
+        const [helper, second, ...rest] = tokens;
+        if (isKV(second)) {
+            return {
+                helper,
+                contextPath: 'this',
+                extras: [second, ...rest].join(' '),
+                impliedThis: true,
+                isStandalonePath: false,
+            };
+        }
+        if (tokens.length >= 2) {
+            const extras = rest.length ? rest.join(' ') : undefined;
+            return { helper, contextPath: second, extras, impliedThis: false, isStandalonePath: false };
+        }
+        return { impliedThis: false, isStandalonePath: false };
+    }
+
+    private static readonly RESERVED_PATHS = new Set<string>([
+        'this',
+        '.',
+        'true',
+        'false',
+        'null',
+        'undefined',
+        'lookup',
+        '@index',
+        '@key',
+        '@first',
+        '@last',
+        '@root',
+    ]);
+
+    private static readonly DOT_AFFINE_KEYS = new Set<string>(['filter', 'sort', 'limit']);
+
+    /**
+     * Separates extra tokens into key-value pairs and positional arguments.
+     * Used to distinguish between helper parameters that need special handling vs simple arguments.
+     */
+    private static splitExtrasFromString(extras: string | undefined): { kvs: string[]; positionals: string[] } {
+        if (!extras) return { kvs: [], positionals: [] };
+        const tokens = TemplatePreprocessor.tokenize(extras);
+        const kvs: string[] = [];
+        const positionals: string[] = [];
+        for (const t of tokens) {
+            if (/^@?[A-Za-z0-9_$-]+=/.test(t)) kvs.push(t);
+            else positionals.push(t);
+        }
+        return { kvs, positionals };
+    }
+
+    /**
+     * Checks if extras contain dot-notation related hash parameters like filter, sort, or limit.
+     * These parameters indicate the path needs convertFromDotNotation wrapping even for simple paths.
+     */
+    private static hasDotNotationHash(extras?: string): boolean {
+        if (!extras) return false;
+        const tokens = TemplatePreprocessor.tokenize(extras);
+        for (const t of tokens) {
+            const m = /^(@?[A-Za-z0-9_$-]+)=/.exec(t);
+            if (m && TemplatePreprocessor.DOT_AFFINE_KEYS.has(m[1])) return true;
+        }
+        return false;
+    }
+
+    /**
+     * Identifies Handlebars control structures like comments, partials, closers, and else blocks.
+     * These segments should never be rewritten and are left unchanged.
+     */
+    private static isControlStructure(body: string): boolean {
+        return /^else\b/i.test(body) || /^[/>!]/.test(body);
+    }
+
+    /**
+     * Determines if a mustache segment is a block opener (starts with # or ^).
+     * Block openers require special handling for context paths and block parameters.
+     */
+    private static isBlockOpener(body: string): boolean {
+        return /^[#^]/.test(body);
+    }
+
+    /**
+     * Extracts block parameters (e.g., "as |item|") from the end of block helper content.
+     * Returns clean content without parameters and the extracted parameter string separately.
+     */
+    private static stripTrailingBlockParams(rest: string): { restNoParams: string; blockParams: string } {
+        let blockParams = '';
+        let restNoParams = rest;
+        const bpMatch = rest.match(/\s+as\s+\|[^|]*\|\s*$/);
+        if (bpMatch) {
+            blockParams = bpMatch[0];
+            restNoParams = rest.slice(0, -bpMatch[0].length).trim();
+        }
+        return { restNoParams, blockParams };
+    }
+
+    /**
+     * Constructs rewritten block helper with convertFromDotNotation wrapper for the context path.
+     * Preserves prefix (#/^), helper name, parameters, and block parameter syntax.
+     */
+    private static buildBlockRewrite(prefix: string, helper: string, safePath: string, kvsPart: string, posPart: string, blockParams: string): string {
+        return `{{${prefix}${helper} (${TemplatePreprocessor.CONVERT_FN} this "${safePath}"${kvsPart})${posPart}${kvsPart}${blockParams}}}`;
+    }
+
+    /**
+     * Creates convertFromDotNotation wrapper for standalone path expressions.
+     * Transforms simple paths like {{foo.bar}} into {{convertFromDotNotation this "foo.bar"}}.
+     */
+    private static buildStandalonePathRewrite(safe: string): string {
+        return `{{${TemplatePreprocessor.CONVERT_FN} this "${safe}"}}`;
+    }
+
+    /**
+     * Adds explicit "this" context to helpers that have implied this (when second token is key-value).
+     * Transforms {{helper key=value}} into {{helper this key=value}}.
+     */
+    private static buildImpliedThisHelperRewrite(helper: string, extras?: string): string {
+        const extrasPart = extras ? ` ${extras}` : '';
+        return `{{${helper} this${extrasPart}}}`;
+    }
+
+    /**
+     * Constructs helper call with convertFromDotNotation wrapper for complex context paths.
+     * Maintains helper name while wrapping the context path and preserving all parameters.
+     */
+    private static buildHelperRewrite(helper: string, safePath: string, kvsPart: string, posPart: string): string {
+        return `{{${helper} (${TemplatePreprocessor.CONVERT_FN} this "${safePath}"${kvsPart})${posPart}${kvsPart}}}`;
+    }
+
+    /**
+     * Checks if a path is reserved (like @index, true, null) but excludes "this" and ".".
+     * Reserved paths should not be wrapped with convertFromDotNotation.
+     */
+    private static isReservedContextExceptThisOrDot(path: string): boolean {
+        return TemplatePreprocessor.RESERVED_PATHS.has(path) && path !== 'this' && path !== '.';
+    }
+
+    /**
+     * Determines if a token is a subexpression wrapped in parentheses.
+     * Subexpressions like (eq a b) should not be rewritten as they have their own evaluation context.
+     */
+    private static isSubexpressionToken(t: string | undefined): boolean {
+        if (!t) return false;
+        const s = t.trim();
+        return s.startsWith('(') && s.endsWith(')');
+    }
+
+    /**
+     * Checks if a path uses relative navigation (../ or ./).
+     * Relative paths should not be wrapped as they have special Handlebars scope semantics.
+     */
+    private static isRelativePath(p: string): boolean {
+        const s = p.trim();
+        return s.startsWith('../') || s.startsWith('./');
+    }
+
+    /**
+     * Tests if a path uses only native Handlebars syntax (simple dots and literal segments).
+     * Native paths don't need convertFromDotNotation unless they have special hash parameters.
+     */
+    private static isNativeHBPath(path: string): boolean {
+        const p = path.trim();
+        if (p === 'this' || p === '.') return true;
+        const IDENT = String.raw`@?[A-Za-z0-9_$-]+`;
+        const LIT_STR = String.raw`"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'`;
+        const LIT_NUM = String.raw`\d+`;
+        const LIT_SEG = String.raw`\[(?:${LIT_STR}|${LIT_NUM})\]`;
+        const DOT_SEG = String.raw`\.(?:${IDENT}|${LIT_SEG})`;
+        const RE = new RegExp(`^(?:${IDENT})(?:${DOT_SEG})*$`);
+        return RE.test(p);
+    }
+
+    /**
+     * Processes entire template to generate rewrite decisions for each mustache segment.
+     * Returns array of decisions indicating whether each segment should be rewritten, left alone, or marked as control.
+     */
+    static analyzeTemplate(template: string): SegmentDecision[] {
+        const segs = TemplatePreprocessor.findMustacheSegments(template);
+        return segs.map(seg => TemplatePreprocessor.analyzeSegment(seg));
+    }
+
+    /**
+     * Analyzes single mustache segment to determine appropriate preprocessing action.
+     * Routes to specialized handlers for control structures, block openers, or regular expressions.
+     */
+    static analyzeSegment(seg: Seg): SegmentDecision {
+        const body = seg.body.trim();
+
+        if (TemplatePreprocessor.isControlStructure(body)) return { kind: 'control', seg };
+
+        if (TemplatePreprocessor.isBlockOpener(body)) {
+            return TemplatePreprocessor.analyzeBlockOpener(seg, body);
+        }
+
+        return TemplatePreprocessor.analyzeNonBlockExpression(seg, body);
+    }
+
+    /**
+     * Evaluates whether a context path needs convertFromDotNotation wrapping based on syntax and parameters.
+     * Returns either a leave decision with reason or prepared components for rewrite construction.
+     */
+    private static prepareRewriteContext(seg: Seg, path: string, extras?: string): { decision?: SegmentDecision; safePath?: string; kvsPart?: string; posPart?: string } {
+        if (TemplatePreprocessor.isSubexpressionToken(path) || TemplatePreprocessor.isRelativePath(path)) {
+            return { decision: { kind: 'leave', seg, reason: 'subexpression-or-relative' } };
+        }
+        if (TemplatePreprocessor.isReservedContextExceptThisOrDot(path)) {
+            return { decision: { kind: 'leave', seg, reason: 'reserved-context' } };
+        }
+        if (path === 'this' || path === '.') {
+            return { decision: { kind: 'leave', seg, reason: 'explicit-this' } };
+        }
+
+        const needsDotAccessor =
+            !TemplatePreprocessor.isNativeHBPath(path) ||
+            TemplatePreprocessor.hasDotNotationHash(extras);
+
+        if (!needsDotAccessor) {
+            return { decision: { kind: 'leave', seg, reason: 'native-handlebars-path' } };
+        }
+
+        const safePath = path.replace(/"/g, '\\"');
+        const { kvs, positionals } = TemplatePreprocessor.splitExtrasFromString(extras);
+        const kvsPart = kvs.length ? ` ${kvs.join(' ')}` : '';
+        const posPart = positionals.length ? ` ${positionals.join(' ')}` : '';
+        return { safePath, kvsPart, posPart };
+    }
+
+    /**
+     * Handles analysis and potential rewriting of block opener expressions like {{#each items}}.
+     * Extracts helper, context path, and parameters while preserving block syntax and parameters.
+     */
+    private static analyzeBlockOpener(seg: Seg, body: string): SegmentDecision {
+        const prefix = body[0];
+        const rest = body.slice(1).trim();
+        const { restNoParams, blockParams } = TemplatePreprocessor.stripTrailingBlockParams(rest);
+        const tokens = TemplatePreprocessor.tokenize(restNoParams);
+        if (tokens.length === 0) return { kind: 'control', seg };
+
+        const { helper, contextPath, extras } = TemplatePreprocessor.interpretTokens(tokens);
+        if (!helper) return { kind: 'invalid', seg, reason: 'no-helper' };
+
+        const path = (contextPath ?? 'this').trim();
+        const prep = TemplatePreprocessor.prepareRewriteContext(seg, path, extras);
+        if (prep.decision) return prep.decision;
+
+        const safePath = prep.safePath!;
+        const kvsPart = prep.kvsPart!;
+        const posPart = prep.posPart!;
+        const newText = TemplatePreprocessor.buildBlockRewrite(prefix, helper, safePath, kvsPart, posPart, blockParams);
+        return { kind: 'rewrite', seg, newText };
+    }
+
+    /**
+     * Processes non-block mustache expressions including standalone paths and helper calls.
+     * Determines if rewriting is needed and constructs appropriate replacement text.
+     */
+    private static analyzeNonBlockExpression(seg: Seg, body: string): SegmentDecision {
+        const tokens = TemplatePreprocessor.tokenize(body);
+        if (tokens.length === 0) return { kind: 'leave', seg, reason: 'empty' };
+
+        if (tokens.length === 1) {
+            const path = tokens[0].trim();
+            const prepSingle = TemplatePreprocessor.prepareRewriteContext(seg, path, undefined);
+            if (prepSingle.decision) {
+                return prepSingle.decision;
+            }
+            const safe = prepSingle.safePath!;
+            return { kind: 'rewrite', seg, newText: TemplatePreprocessor.buildStandalonePathRewrite(safe) };
+        }
+
+        const { helper, contextPath, extras, impliedThis } = TemplatePreprocessor.interpretTokens(tokens);
+        if (!helper) return { kind: 'invalid', seg, reason: 'no-helper' };
+
+        const path = (contextPath ?? 'this').trim();
+
+        if (impliedThis) {
+            const newText = TemplatePreprocessor.buildImpliedThisHelperRewrite(helper, extras);
+            return { kind: 'rewrite', seg, newText };
+        }
+
+        const prep = TemplatePreprocessor.prepareRewriteContext(seg, path, extras);
+        if (prep.decision) return prep.decision;
+
+        const safePath = prep.safePath!;
+        const kvsPart = prep.kvsPart!;
+        const posPart = prep.posPart!;
+        const newText = TemplatePreprocessor.buildHelperRewrite(helper, safePath, kvsPart, posPart);
+        return { kind: 'rewrite', seg, newText };
+    }
+
+    /**
+     * Type guard to filter segment decisions that require rewriting.
+     * Used in preprocessing pipeline to identify segments that need text replacement.
+     */
+    private static isRewrite(d: SegmentDecision): d is Extract<SegmentDecision, { kind: 'rewrite' }> {
+        return d.kind === 'rewrite';
+    }
+
+    /**
+     * Main entry point that transforms template by applying all necessary rewrites.
+     * Processes segments from right to left to maintain correct string indices during replacement.
+     */
     static preprocessTemplate(template: string): string {
-        // Handlebars control structures and built-in keywords that should not be processed
-        const handlebarsKeywords = new Set([
-            'else', 'if', 'unless', 'each', 'with', 'lookup', 'this',
-            'true', 'false', 'null', 'undefined', '@index', '@key', '@first', '@last'
-        ]);
+        const decisions = TemplatePreprocessor.analyzeTemplate(template);
+        const replacements = decisions
+            .filter(TemplatePreprocessor.isRewrite)
+            .map(d => ({ start: d.seg.start, end: d.seg.end, newText: d.newText }))
+            .sort((a, b) => b.start - a.start);
 
-        // Matches helper-based calls like: {{list nodes[...] ...}}
-        const helperPattern =
-            /{{\s*(\w+)\s+((?:\w+|\[[^\]]+\]|\.|\['[^']+'']|\.\w+)+)((?:\s+\w+="[^"]*")*)\s*}}/g;
-
-        // Matches standalone paths like: {{nodes[...]}}
-        const extractablePattern =
-            /{{\s*((?:\w+|\[[^\]]+\]|\.|\['[^']+'']|\.\w+)+)\s*}}/g;
-
-        // Replace helper-based matches
-        template = template.replace(helperPattern, (_match, helper, path, extras) => {
-            // Skip if the path is a Handlebars keyword
-            if (handlebarsKeywords.has(path.trim())) {
-                return _match;
-            }
-            const safePath = path.replace(/"/g, '\\"');
-            //TODO: What happens if a widget has same helper function as the DotNotation helper filter + sort etc?
-            return `{{${helper} (convertFromDotNotation this "${safePath}" ${extras})${extras}}}`;
-        });
-
-        // Replace standalone paths, but exclude Handlebars keywords
-        return template.replace(extractablePattern, (_match, path) => {
-            // Skip if it's a Handlebars keyword or control structure
-            if (handlebarsKeywords.has(path.trim())) {
-                return _match; // Return unchanged
-            }
-
-            const safePath = path.replace(/"/g, '\\"');
-            return `{{convertFromDotNotation this "${safePath}"}}`;
-        });
+        let out = template;
+        for (const r of replacements) {
+            out = out.slice(0, r.start) + r.newText + out.slice(r.end);
+        }
+        return out;
     }
 }


### PR DESCRIPTION
## Description
Fixes pre-parsing of DotNotation in certain situations as mentioned on https://github.com/finos/architecture-as-code/issues/1556#issuecomment-3243213264 

```hbs
{{json-viewer nodes['load-balancer'] }}
```

The logic has been altered to be less aggressive in passing paths to the convertToDotNotation helper function. In addition adds diagnostics to the pre-parsing and defaults this context if not specified

```hbs
{{flow-sequence flow-id="test"}}
```

## Type of Change
<!-- Check the type that applies to your PR -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [x] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [ ] CLI (`cli/`)
- [x] Shared (`shared/`)
- [x] CALM Widgets (`calm-widgets/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] Documentation (`docs/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format ✅
<!-- 
Make sure your commit messages follow the conventional commit format:
type(scope): description

Scope is optional but recommended - you can use ./commit-helper.sh to get suggestions!

Examples:
- feat(cli): add new validation command
- fix(shared): resolve schema parsing issue
- docs: update installation guide
- chore(deps): bump typescript to 5.8.3

This helps with our automated versioning and changelog generation!
Note: Only commits with (cli) scope will trigger CLI releases.
-->

## Testing
<!-- Describe how you tested your changes -->
- [x] I have tested my changes locally
- [x] I have added/updated unit tests
- [x] All existing tests pass

## Checklist
- [x] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [x] I have updated documentation if necessary
- [x] I have added tests for my changes (if applicable)
- [x] My changes follow the project's coding standards
