### PR TITLE
feat(docify): Allow for tempalte bundles to have nested structure (#1032)

### DIFF
--- a/shared/src/template/template-bundle-file-loader.spec.ts
+++ b/shared/src/template/template-bundle-file-loader.spec.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { TemplateBundleFileLoader, SelfProvidedTemplateLoader, SelfProvidedDirectoryTemplateLoader } from './template-bundle-file-loader';
+import { TemplateBundleFileLoader, SelfProvidedTemplateLoader, SelfProvidedDirectoryTemplateLoader, walkTemplateDirectory, buildFrontMatterConfig } from './template-bundle-file-loader';
 import { IndexFile } from './types';
 import { Mock } from 'vitest';
 
@@ -16,6 +16,8 @@ describe('TemplateBundleFileLoader', () => {
 
     beforeEach(() => {
         vi.resetAllMocks();
+        // Default: treat every entry as a file unless a test overrides this.
+        (fs.statSync as Mock).mockReturnValue({ isDirectory: () => false });
     });
 
     it('should load index.json and template files correctly', () => {
@@ -87,6 +89,52 @@ describe('TemplateBundleFileLoader', () => {
 
         const loader = new TemplateBundleFileLoader(mockBundlePath);
         expect(loader.getTemplateFiles()).toEqual({});
+    });
+
+    it('should recursively load templates from nested directories keyed by relative path', () => {
+        const dirs = new Set([
+            mockBundlePath,
+            path.join(mockBundlePath, 'templates'),
+            path.join(mockBundlePath, 'templates', 'pages'),
+            path.join(mockBundlePath, 'partials'),
+        ]);
+
+        const fileContents: Record<string, string> = {
+            [mockIndexJsonPath]: JSON.stringify({
+                name: 'nested-bundle',
+                transformer: 'my-transformer',
+                templates: [{
+                    template: 'templates/pages/node.hbs',
+                    from: 'document.nodes',
+                    output: '{{id}}.md',
+                    'output-type': 'repeated',
+                    partials: ['partials/rel.hbs'],
+                }],
+            } as IndexFile),
+            [path.join(mockBundlePath, 'templates', 'pages', 'node.hbs')]: '{{name}} {{> partials/rel.hbs}}',
+            [path.join(mockBundlePath, 'partials', 'rel.hbs')]: 'rel partial',
+            [path.join(mockBundlePath, 'my-transformer.ts')]: 'export default {}',
+        };
+
+        const childrenOf: Record<string, string[]> = {
+            [mockBundlePath]: ['index.json', 'my-transformer.ts', 'templates', 'partials'],
+            [path.join(mockBundlePath, 'templates')]: ['pages'],
+            [path.join(mockBundlePath, 'templates', 'pages')]: ['node.hbs'],
+            [path.join(mockBundlePath, 'partials')]: ['rel.hbs'],
+        };
+
+        (fs.existsSync as Mock).mockImplementation((filePath: string) => filePath === mockIndexJsonPath);
+        (fs.readFileSync as Mock).mockImplementation((filePath: string) => fileContents[filePath]);
+        (fs.readdirSync as Mock).mockImplementation((dirPath: string) => childrenOf[dirPath] ?? []);
+        (fs.statSync as Mock).mockImplementation((p: string) => ({ isDirectory: () => dirs.has(p) }));
+
+        const loader = new TemplateBundleFileLoader(mockBundlePath);
+        const files = loader.getTemplateFiles();
+
+        expect(Object.keys(files).sort()).toEqual(['partials/rel.hbs', 'templates/pages/node.hbs']);
+        expect(files['templates/pages/node.hbs']).toContain('{{> partials/rel.hbs}}');
+        expect(files).not.toHaveProperty('index.json');
+        expect(files).not.toHaveProperty('my-transformer.ts');
     });
 });
 
@@ -312,6 +360,66 @@ widget-options:
                     'output-type': 'single'
                 }
             ]
+        });
+    });
+});
+
+describe('walkTemplateDirectory', () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+    });
+
+    it('should visit every file with forward-slash relative paths, recursing into subdirectories', () => {
+        const root = '/root';
+        const dirs = new Set([root, path.join(root, 'sub'), path.join(root, 'sub', 'deep')]);
+        const childrenOf: Record<string, string[]> = {
+            [root]: ['top.hbs', 'sub'],
+            [path.join(root, 'sub')]: ['mid.hbs', 'deep'],
+            [path.join(root, 'sub', 'deep')]: ['leaf.hbs'],
+        };
+
+        (fs.readdirSync as Mock).mockImplementation((dir: string) => childrenOf[dir] ?? []);
+        (fs.statSync as Mock).mockImplementation((p: string) => ({ isDirectory: () => dirs.has(p) }));
+
+        const visited: string[] = [];
+        walkTemplateDirectory(root, (_fullPath, relPath) => visited.push(relPath));
+
+        expect(visited.sort()).toEqual(['sub/deep/leaf.hbs', 'sub/mid.hbs', 'top.hbs']);
+    });
+
+    it('should pass the absolute full path to the visitor', () => {
+        const root = '/root';
+        (fs.readdirSync as Mock).mockImplementation((dir: string) => (dir === root ? ['a.hbs'] : []));
+        (fs.statSync as Mock).mockReturnValue({ isDirectory: () => false });
+
+        const fullPaths: string[] = [];
+        walkTemplateDirectory(root, (fullPath) => fullPaths.push(fullPath));
+
+        expect(fullPaths).toEqual([path.join(root, 'a.hbs')]);
+    });
+});
+
+describe('buildFrontMatterConfig', () => {
+    it('should return undefined when neither variables nor widget options are present', () => {
+        expect(buildFrontMatterConfig({}, {})).toBeUndefined();
+    });
+
+    it('should include only variables when no widget options are present', () => {
+        expect(buildFrontMatterConfig({ name: 'Doc' }, {})).toEqual({
+            variables: { name: 'Doc' }
+        });
+    });
+
+    it('should include only widget options when no variables are present', () => {
+        expect(buildFrontMatterConfig({}, { 'sample-widget': { enabled: false } })).toEqual({
+            widgetOptions: { 'sample-widget': { enabled: false } }
+        });
+    });
+
+    it('should include both variables and widget options when present', () => {
+        expect(buildFrontMatterConfig({ name: 'Doc' }, { 'sample-widget': { enabled: true } })).toEqual({
+            variables: { name: 'Doc' },
+            widgetOptions: { 'sample-widget': { enabled: true } }
         });
     });
 });

--- a/shared/src/template/template-bundle-file-loader.ts
+++ b/shared/src/template/template-bundle-file-loader.ts
@@ -12,6 +12,82 @@ export interface ITemplateBundleLoader {
     getTemplateFiles(): Record<string, string>;
 }
 
+interface ExtractedFrontMatter {
+    content: string;
+    variables: Record<string, string>;
+    widgetOptions: WidgetsOptions;
+}
+
+/**
+ * Recursively walk a directory, invoking `visit` for every file (not directory).
+ * `relPath` is the file's path relative to `rootDir`, normalized to forward slashes
+ * so keys are stable across platforms.
+ */
+export function walkTemplateDirectory(
+    rootDir: string,
+    visit: (fullPath: string, relPath: string) => void
+): void {
+    const recurse = (dir: string, relativePath: string): void => {
+        for (const item of fs.readdirSync(dir)) {
+            const fullPath = path.join(dir, item);
+            const relPath = relativePath ? `${relativePath}/${item}` : item;
+
+            if (fs.statSync(fullPath).isDirectory()) {
+                recurse(fullPath, relPath);
+            } else {
+                visit(fullPath, relPath);
+            }
+        }
+    };
+    recurse(rootDir, '');
+}
+
+/**
+ * Parse and resolve front-matter for a template's content, returning the resolved
+ * content alongside any string variables and widget options it declared.
+ */
+export function extractFrontMatter(content: string, dir: string): ExtractedFrontMatter {
+    const parsed = parseFrontMatterFromContent(content, dir);
+    const variables: Record<string, string> = {};
+    const widgetOptions: WidgetsOptions = {};
+    let resolvedContent = content;
+
+    if (parsed && Object.keys(parsed.frontMatter).length > 0) {
+        resolvedContent = replaceVariables(content, parsed.frontMatter);
+        for (const [key, value] of Object.entries(parsed.frontMatter)) {
+            if (typeof value === 'string') {
+                variables[key] = value;
+            }
+            if (key === 'widget-options' && typeof value === 'object' && value !== null) {
+                Object.assign(widgetOptions, value);
+            }
+        }
+    }
+
+    return { content: resolvedContent, variables, widgetOptions };
+}
+
+/**
+ * Build a TemplateEntry `front-matter` object from extracted variables/widget options,
+ * or `undefined` when neither is present.
+ */
+export function buildFrontMatterConfig(
+    variables: Record<string, string>,
+    widgetOptions: WidgetsOptions
+): TemplateEntry['front-matter'] | undefined {
+    const hasVariables = Object.keys(variables).length > 0;
+    const hasWidgetOptions = Object.keys(widgetOptions).length > 0;
+
+    if (!hasVariables && !hasWidgetOptions) {
+        return undefined;
+    }
+
+    return {
+        ...(hasVariables ? { variables } : {}),
+        ...(hasWidgetOptions ? { widgetOptions } : {})
+    };
+}
+
 export class SelfProvidedTemplateLoader implements ITemplateBundleLoader {
     private readonly config: IndexFile;
     private readonly templateFiles: Record<string, string>;
@@ -28,25 +104,11 @@ export class SelfProvidedTemplateLoader implements ITemplateBundleLoader {
             ? 'output.md'
             : path.basename(outputPath);
 
-        let templateContent = fs.readFileSync(templatePath, 'utf8');
-        const parsed = parseFrontMatterFromContent(templateContent, templateDir);
-
-        const frontMatterVariables: Record<string, string> = {};
-        const widgetOptions: WidgetsOptions = {};
-        if (parsed && Object.keys(parsed.frontMatter).length > 0) {
-            templateContent = replaceVariables(templateContent, parsed.frontMatter);
-            for (const [key, value] of Object.entries(parsed.frontMatter)) {
-                if (typeof value === 'string') {
-                    frontMatterVariables[key] = value;
-                }
-                if (key === 'widget-options' && typeof value === 'object' && value !== null) {
-                    Object.assign(widgetOptions, value);
-                }
-            }
-        }
+        const rawContent = fs.readFileSync(templatePath, 'utf8');
+        const { content, variables, widgetOptions } = extractFrontMatter(rawContent, templateDir);
 
         this.templateFiles = {
-            [templateName]: templateContent
+            [templateName]: content
         };
 
         this.config = {
@@ -59,11 +121,9 @@ export class SelfProvidedTemplateLoader implements ITemplateBundleLoader {
             }]
         };
 
-        if (Object.keys(frontMatterVariables).length > 0 || Object.keys(widgetOptions).length > 0) {
-            this.config.templates[0]['front-matter'] = {
-                ...(Object.keys(frontMatterVariables).length > 0 ? { variables: frontMatterVariables } : {}),
-                ...(Object.keys(widgetOptions).length > 0 ? { widgetOptions: widgetOptions } : {})
-            };
+        const frontMatter = buildFrontMatterConfig(variables, widgetOptions);
+        if (frontMatter) {
+            this.config.templates[0]['front-matter'] = frontMatter;
         }
     }
 
@@ -81,58 +141,28 @@ export class SelfProvidedDirectoryTemplateLoader implements ITemplateBundleLoade
     private readonly templateFiles: Record<string, string> = {};
 
     constructor(templateDir: string) {
-
         const entries: TemplateEntry[] = [];
 
-        const loadFilesRecursively = (dir: string, relativePath: string = '') => {
-            const items = fs.readdirSync(dir);
-            for (const item of items) {
-                const fullPath = path.join(dir, item);
-                const relPath = relativePath ? path.join(relativePath, item) : item;
+        walkTemplateDirectory(templateDir, (fullPath, relPath) => {
+            const rawContent = fs.readFileSync(fullPath, 'utf8');
+            const { content, variables, widgetOptions } = extractFrontMatter(rawContent, path.dirname(fullPath));
 
-                if (fs.statSync(fullPath).isDirectory()) {
-                    loadFilesRecursively(fullPath, relPath);
-                } else {
-                    let templateContent = fs.readFileSync(fullPath, 'utf8');
-                    const templateFileDir = path.dirname(fullPath);
-                    const parsed = parseFrontMatterFromContent(templateContent, templateFileDir);
+            this.templateFiles[relPath] = content;
 
-                    const frontMatterVariables: Record<string, string> = {};
-                    const widgetOptions: WidgetsOptions = {};
-                    if (parsed && Object.keys(parsed.frontMatter).length > 0) {
-                        templateContent = replaceVariables(templateContent, parsed.frontMatter);
-                        for (const [key, value] of Object.entries(parsed.frontMatter)) {
-                            if (typeof value === 'string') {
-                                frontMatterVariables[key] = value;
-                            }
-                            if (key === 'widget-options' && typeof value === 'object' && value !== null) {
-                                Object.assign(widgetOptions, value);
-                            }
-                        }
-                    }
+            const entry: TemplateEntry = {
+                template: relPath,
+                from: 'document',
+                output: relPath,
+                'output-type': 'single'
+            };
 
-                    this.templateFiles[relPath] = templateContent;
-
-                    const entry: TemplateEntry = {
-                        template: relPath,
-                        from: 'document',
-                        output: relPath,
-                        'output-type': 'single'
-                    };
-
-                    if (Object.keys(frontMatterVariables).length > 0 || Object.keys(widgetOptions).length > 0) {
-                        entry['front-matter'] = {
-                            ...(Object.keys(frontMatterVariables).length > 0 ? { variables: frontMatterVariables } : {}),
-                            ...(Object.keys(widgetOptions).length > 0 ? { widgetOptions: widgetOptions } : {})
-                        };
-                    }
-
-                    entries.push(entry);
-                }
+            const frontMatter = buildFrontMatterConfig(variables, widgetOptions);
+            if (frontMatter) {
+                entry['front-matter'] = frontMatter;
             }
-        };
 
-        loadFilesRecursively(templateDir);
+            entries.push(entry);
+        });
 
         this.config = {
             name: 'Self Provided Template Directory',
@@ -198,20 +228,36 @@ export class TemplateBundleFileLoader implements ITemplateBundleLoader {
     private loadTemplateFiles(): Record<string, string> {
         const logger = TemplateBundleFileLoader.logger;
         const templates: Record<string, string> = {};
-        const templateDir = this.templateBundlePath;
 
-        logger.info(`📂 Loading template files from: ${templateDir}`);
+        logger.info(`📂 Loading template files from: ${this.templateBundlePath}`);
 
-        const templateFiles = fs.readdirSync(templateDir).filter(file => file.includes('.'));
-
-        for (const file of templateFiles) {
-            const filePath = path.join(templateDir, file);
-            templates[file] = fs.readFileSync(filePath, 'utf8');
-            logger.debug(`✅ Loaded template file: ${file}`);
-        }
+        walkTemplateDirectory(this.templateBundlePath, (fullPath, relPath) => {
+            if (!this.isLoadableTemplate(relPath, path.basename(fullPath))) {
+                return;
+            }
+            templates[relPath] = fs.readFileSync(fullPath, 'utf8');
+            logger.debug(`✅ Loaded template file: ${relPath}`);
+        });
 
         logger.info(`🎯 Total Templates Loaded: ${Object.keys(templates).length}`);
         return templates;
+    }
+
+    /**
+     * A bundle file is loadable as a template unless it is the index.json manifest
+     * or the transformer source file. Files without an extension are ignored.
+     */
+    private isLoadableTemplate(relPath: string, fileName: string): boolean {
+        if (relPath === 'index.json') {
+            return false;
+        }
+
+        const transformer = this.config.transformer;
+        if (transformer && (relPath === `${transformer}.ts` || relPath === `${transformer}.js`)) {
+            return false;
+        }
+
+        return fileName.includes('.');
     }
 
     public getConfig(): IndexFile {

--- a/shared/src/template/template-processor.e2e.spec.ts
+++ b/shared/src/template/template-processor.e2e.spec.ts
@@ -135,6 +135,30 @@ describe('TemplateProcessor E2E', () => {
         expect(actualContent).toEqual(expectedContent); // Compare file contents
     });
 
+    it('should process a bundle whose templates and partials live in nested directories', async () => {
+        const processor = new TemplateProcessor(
+            path.join(DATA_DIR, 'document-system.json'),
+            path.join(FIXTURES_DIR, 'bundles/nested-with-partials'),
+            OUTPUT_DIR,
+            new Map<string, string>()
+        );
+        await processor.processTemplate();
+
+        const actualFile = path.join(OUTPUT_DIR, 'actual-nested-with-partials.txt');
+        // Nested bundle must produce identical output to the equivalent flat bundle.
+        const expectedFile = path.join(
+            EXPECTED_OUTPUT_DIR,
+            'with-partials.txt'
+        );
+
+        expect(fs.existsSync(actualFile)).toBe(true);
+
+        const actualContent = fs.readFileSync(actualFile, 'utf8').trim();
+        const expectedContent = fs.readFileSync(expectedFile, 'utf8').trim();
+
+        expect(actualContent).toEqual(expectedContent);
+    });
+
     it('should process a bundle with repeated output', async () => {
         const processor = new TemplateProcessor(
             path.join(DATA_DIR, 'simple-nodes.json'),

--- a/shared/test_fixtures/template/bundles/nested-with-partials/index.json
+++ b/shared/test_fixtures/template/bundles/nested-with-partials/index.json
@@ -1,0 +1,13 @@
+{
+  "name": "CALM-Based Nested Partial Template Bundle",
+  "transformer": "nested-transformer",
+  "templates": [
+    {
+      "template": "templates/pages/main.hbs",
+      "from": "document",
+      "output": "actual-nested-with-partials.txt",
+      "output-type": "single",
+      "partials": ["partials/header.hbs", "partials/footer.hbs"]
+    }
+  ]
+}

--- a/shared/test_fixtures/template/bundles/nested-with-partials/nested-transformer.ts
+++ b/shared/test_fixtures/template/bundles/nested-with-partials/nested-transformer.ts
@@ -1,0 +1,31 @@
+/* eslint-disable  @typescript-eslint/no-explicit-any */
+import {CalmTemplateTransformer} from '../../../../src/template/types';
+import {CalmCore} from '../../../../src/model/core.js';
+
+export class CalmTransformer implements CalmTemplateTransformer {
+    registerTemplateHelpers(): Record<string, (...args: any[]) => any> {
+        return {
+            uppercase: (text: string) => text.toUpperCase(),
+            lookup: (nodes: Array<Record<string, any>>, id: string) => {
+                return nodes.find(node => node['unique-id'] === id)?.name ?? `Unknown (${id})`;
+            }
+        };
+    }
+
+    getTransformedModel(architecture: CalmCore): any {
+
+        const parsed = architecture.toCanonicalSchema();
+
+        return {
+            document: {
+                id: parsed.metadata['id'],
+                name: parsed['name'],
+                description: parsed.metadata['description'],
+                nodes: parsed.nodes || [],
+                relationships: parsed.relationships || []
+            }
+        };
+    }
+}
+
+export default CalmTransformer;

--- a/shared/test_fixtures/template/bundles/nested-with-partials/partials/footer.hbs
+++ b/shared/test_fixtures/template/bundles/nested-with-partials/partials/footer.hbs
@@ -1,0 +1,3 @@
+===========================================
+This document is auto-generated based on architecture standards.
+===== END OF REPORT =====

--- a/shared/test_fixtures/template/bundles/nested-with-partials/partials/header.hbs
+++ b/shared/test_fixtures/template/bundles/nested-with-partials/partials/header.hbs
@@ -1,0 +1,3 @@
+===== ARCHITECTURE REVIEW =====
+System generated report based on CALM Model
+===========================================

--- a/shared/test_fixtures/template/bundles/nested-with-partials/templates/pages/main.hbs
+++ b/shared/test_fixtures/template/bundles/nested-with-partials/templates/pages/main.hbs
@@ -1,0 +1,18 @@
+{{> partials/header.hbs }}
+
+## Nodes
+{{#each nodes}}
+    ### {{uppercase node-type}}: {{name}}
+    - **ID:** {{unique-id}}
+    - **Description:** {{description}}
+{{/each}}
+
+## Relationships
+{{#each relationships}}
+    {{#if relationship-type.connects}}
+        ### {{relationship-type.connects.source.node}} → {{relationship-type.connects.destination.node}}
+        - **Description:** {{description}}
+    {{/if}}
+{{/each}}
+
+{{> partials/footer.hbs }}


### PR DESCRIPTION


## Description
<!-- Provide a brief description of your changes -->

## Type of Change
<!-- Check the type that applies to your PR -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvements
- [ ] ✅ Test additions or updates
- [ ] 🔧 Chore (maintenance, dependencies, CI, etc.)

## Affected Components
<!-- Check all that apply -->
- [ ] CLI (`cli/`)
- [ ] Schema (`calm/`)
- [ ] CALM AI (`calm-ai/`)
- [ ] CALM Hub (`calm-hub/`)
- [ ] CALM Hub UI (`calm-hub-ui/`)
- [ ] CALM Server (`calm-server/`)
- [ ] CALM Widgets (`calm-widgets/`)
- [ ] Documentation (`docs/`)
- [ ] Shared (`shared/`)
- [ ] VS Code Extension (`calm-plugins/vscode/`)
- [ ] Dependencies
- [ ] CI/CD

## Commit Message Format ✅
<!-- 
Make sure your commit messages follow the conventional commit format:
type(scope): description

Scope is optional but recommended - you can use ./commit-helper.sh to get suggestions!

Examples:
- feat(cli): add new validation command
- fix(shared): resolve schema parsing issue
- docs: update installation guide
- chore(deps): bump typescript to 5.8.3

This helps with our automated versioning and changelog generation!
Note: Only commits with (cli) scope will trigger CLI releases.
-->

## Testing
<!-- Describe how you tested your changes -->
- [ ] I have tested my changes locally
- [ ] I have added/updated unit tests
- [ ] All existing tests pass

## Checklist
- [ ] My commits follow the [conventional commit format](https://www.conventionalcommits.org/)
- [ ] I have updated documentation if necessary
- [ ] I have added tests for my changes (if applicable)
- [ ] My changes follow the project's coding standards
