### PR TITLE
fix(calm-ai): fix typo in relationship-creation prompt

### DIFF
--- a/calm-ai/tools/relationship-creation.md
+++ b/calm-ai/tools/relationship-creation.md
@@ -180,7 +180,7 @@ them as they convey rich information about how the overall architecture actually
 Descriptions should be concise but clarify the _intent_ of the relationship.  The preferred style is to omit the source and
 destination node names, but be very clear as to the directionality.  Examples:
 - "Reads customer information from and writes to" (e.g. a service querying a database)
-- "Sends traansactions to" (e.g. one service sending to another via a message queue)
+- "Sends transactions to" (e.g. one service sending to another via a message queue)
 - "Reviews trade summaries using" (e.g. a human interacting with a UI)
 
 ### Available Protocol Values


### PR DESCRIPTION
Fixing typos in the relationship-creation AI prompt file.